### PR TITLE
Added random_padding, SetEDNSSubnet

### DIFF
--- a/httpdig.go
+++ b/httpdig.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strings"
+	"time"
 )
 
 var apiURL = "https://dns.google.com/resolve"
@@ -26,17 +27,17 @@ type Response struct {
 	} `json:"Question"`
 
 	Answer []struct {
-		Name string `json:"name"`
-		Type int    `json:"type"`
-		TTL  int    `json:"TTL"`
-		Data string `json:"data"`
+		Name string        `json:"name"`
+		Type int           `json:"type"`
+		TTL  time.Duration `json:"TTL"`
+		Data string        `json:"data"`
 	} `json:"Answer"`
 
 	Authority []struct {
-		Name string `json:"name"`
-		Type int    `json:"type"`
-		TTL  int    `json:"TTL"`
-		Data string `json:"data"`
+		Name string        `json:"name"`
+		Type int           `json:"type"`
+		TTL  time.Duration `json:"TTL"`
+		Data string        `json:"data"`
 	} `json:"Authority"`
 
 	Additional       []interface{} `json:"Additional"`
@@ -80,6 +81,14 @@ func Query(host string, t string) (Response, error) {
 
 	response := Response{}
 	err = json.Unmarshal(resp, &response)
+
+	// scale TTL fields to seconds of duration instead of ns
+	for i := range response.Answer {
+		response.Answer[i].TTL *= time.Second
+	}
+	for i := range response.Authority {
+		response.Authority[i].TTL *= time.Second
+	}
 
 	if err != nil {
 		return Response{}, err


### PR DESCRIPTION
I've added `random_padding` such that the request length is consistent, no matter what domain you're querying for.  It just takes `$MAXLEN` (which is 253 chars) and subtracts the `len($DOMAIN)` and fills that space with `0`.  If you change other things, like the record type, you're on your own.  Technically one could include even that into the length calculation, but I didn't.

I also added a function that allows you to override the default `ednsSubnet` value with something else, or empty string.

In addition, in a separate commit that you're certainly under no pressure to accept, I've moved the TTL fields from `int` to `time.Duration`.  It would break existing use of that field, so take it or leave it.  If you take it, keep in mind that you can convert back to old behavior by throwing a `.Seconds()` on the end, like `r.Answers[0].TTL.Seconds()` instead of `r.Answers[0].TTL`.